### PR TITLE
Make it clear that Rusqlite supports SQLCipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Support for SQLCipher is now available in [Rusqlite](https://github.com/rusqlite/rusqlite)
+
+Use [Rusqlite](https://github.com/rusqlite/rusqlite) with SQLCipher support by adding this to your Cargo.toml:
+
+```toml
+[dependencies.rusqlite]
+version = "0.23.1"
+features = ["sqlcipher"]
+```
+
 # Rusqlcipher
 
 [![Travis Build Status](https://api.travis-ci.org/jgallagher/rusqlite.svg?branch=master)](https://travis-ci.org/jgallagher/rusqlite)


### PR DESCRIPTION
I didn't realize that Rusqlite has added support for SQLCipher so I got confused and installed the wrong package. Since Rusqlcipher is still a prominent search engine result, I propose adding some info to the readme to prevent future mixups.